### PR TITLE
Fix ++= arg type

### DIFF
--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
@@ -132,7 +132,7 @@ trait BlockingJdbcProfile extends JdbcProfile with BlockingRelationalProfile {
       }
     }
 
-    def ++=(values: U*)(implicit s: JdbcBackend#Session): Int = insertAll(values: _*)
+    def ++=(values: Iterable[U])(implicit s: JdbcBackend#Session): Int = insertAll(values.toSeq: _*)
 
     // TODO should be batch insert
     def insertAll(values: U*)(implicit s: JdbcBackend#Session): Int = {

--- a/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
+++ b/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
@@ -5,7 +5,8 @@ import org.scalatest.FunSuite
 class SlickBlockingAPISpec extends FunSuite {
 
   import BlockingH2Driver._
-  import BlockingH2Driver.blockingApi._
+  // queryInsertActionExtensionMethods is conflicted with BlockingH2Driver.InsertActionExtensionMethods
+  import BlockingH2Driver.blockingApi.{ queryInsertActionExtensionMethods => _, _ }
   import models.Tables._
 
   private val db = Database.forURL("jdbc:h2:mem:test")
@@ -86,6 +87,26 @@ class SlickBlockingAPISpec extends FunSuite {
       assert(exists2 == true)
 
       models.Tables.schema.remove
+    }
+  }
+
+  test("insertAll"){
+    db.withSession { implicit session =>
+      models.Tables.schema.create
+
+      val users = List(
+        UsersRow(1, "takezoe", None),
+        UsersRow(2, "chibochibo", None),
+        UsersRow(3, "tanacasino", None)
+      )
+
+      Users.insertAll(users: _*)
+      val count1 = Query(Users.length).first
+      assert(count1 == 3)
+
+      Users ++= users
+      val count2 = Query(Users.length).first
+      assert(count2 == 6)
     }
   }
 


### PR DESCRIPTION
Hi @takezoe! Thank you for the great library!!!

Sorry for the nit pull request, but I think `++=` method should accept `Iterable[U]` instead of `U*` to be compatible with slick2.x
https://github.com/slick/slick/blob/10d3e44c5bf5f0418c6017b57be3b49646c8dcbe/src/main/scala/scala/slick/driver/JdbcInsertInvokerComponent.scala#L71

In test file, this pull-request hides implicit `BlockingH2Driver.blockingApi.queryInsertActionExtensionMethods` because it's conflicted with `BlockingH2Driver.InsertActionExtensionMethods`

i guess it's better to fix this conflict in the first place, but I couldn't find a way to fix it...

It's not related with this pull-request, but I also tried to fix the TODO (`// TODO should be batch insert`), but it's difficult for me to fix it...
