### PR TITLE
Support session.withTransaction

### DIFF
--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
@@ -194,22 +194,8 @@ trait BlockingJdbcProfile extends JdbcProfile with BlockingRelationalProfile wit
       }
     }
 
-    def withTransaction[T](f: (JdbcBackend#Session) => T): T = {
-      val session = db.createSession()
-      session.conn.setAutoCommit(false)
-      try {
-        val result = f(session)
-        session.conn.commit()
-        result
-      } catch {
-        case e: Exception =>
-          session.conn.rollback()
-          throw e
-      } finally {
-        session.close()
-      }
-    }
-
+    def withTransaction[T](f: (JdbcBackend#Session) => T): T =
+      withSession { s => s.withTransaction(f(s)) }
   }
 
   implicit class SqlStreamingActionInvoker[R](action: SqlStreamingAction[Vector[R], R, Effect]){

--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
@@ -20,7 +20,7 @@ trait BlockingRelationalProfile extends RelationalProfile {
   trait BlockingAPI extends API {}
 }
 
-trait BlockingJdbcProfile extends JdbcProfile with BlockingRelationalProfile {
+trait BlockingJdbcProfile extends JdbcProfile with BlockingRelationalProfile with slick.TransactionalJdbcProfile {
 
   val blockingApi = new BlockingAPI with ImplicitColumnTypes {}
   implicit def actionBasedSQLInterpolation(s: StringContext) = new ActionBasedSQLInterpolation(s)

--- a/src/main/scala/slick/TransactionalJdbcBackend.scala
+++ b/src/main/scala/slick/TransactionalJdbcBackend.scala
@@ -1,0 +1,35 @@
+package slick
+
+import slick.jdbc.JdbcBackend
+
+// TransactionalJdbcBackend brings back withTransaction feature from slick 2.x
+// (it's also related with 3.0).
+//
+// It cannot use `session.rollback` because we cannot touch `protected var doRollback`.
+// Use `session.conn.rollback()` instead.
+//
+// ref:
+// - https://github.com/slick/slick/blob/3.0/slick/src/main/scala/slick/jdbc/JdbcBackend.scala#L424
+// - https://github.com/slick/slick/blob/2.1/src/main/scala/scala/slick/jdbc/JdbcBackend.scala#L419
+// - https://github.com/slick/slick/blob/3.1/slick/src/main/scala/slick/jdbc/JdbcBackend.scala#L407
+trait TransactionalJdbcProfile {
+  /**
+   * Extends Session to add methods for session management.
+   */
+  implicit class BlockingSession(session: JdbcBackend#Session) {
+    def withTransaction[T](f: => T): T = {
+      val s = session.asInstanceOf[JdbcBackend#BaseSession]
+      s.isInTransaction
+      if(s.isInTransaction) f else {
+        s.startInTransaction
+        var done = false
+        try {
+          val res = f
+          s.endInTransaction(s.conn.commit())
+          done = true
+          res
+        } finally if(!done) s.endInTransaction(s.conn.rollback())
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi, there!

I added session.withTransaction support which is provided in slick 2.x.
blocking-slick currently supports `JdbcBackend#DatabaseDef.withTransaction`, but it can't be nested.

The API is not completely compatible with slick2.x because it lackes `session.rollback()` support.
So, blocking-slick users have to use `session.conn.rollback()` instead.

It's not a clean patch and I'm not sure it supports all usecases, but it works good and I think it might be worth considering to add to blocking-slick.

Thanks in advance.
