### PR TITLE
slick 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
+  - 2.10.6
   - 2.11.8
-  - 2.12.1
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
-name := "blocking-slick"
+name := "blocking-slick-31"
 
 organization := "com.github.takezoe"
 
 version := "0.0.4"
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := List("2.11.8", "2.12.1")
+crossScalaVersions := List("2.10.6", "2.11.8")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick"           % "3.2.0-M2",
+  "com.typesafe.slick" %% "slick"           % "3.1.1",
   "org.scalatest"      %% "scalatest"       % "3.0.1"   % "test",
   "com.h2database"      % "h2"              % "1.4.192" % "test",
   "ch.qos.logback"      % "logback-classic" % "1.1.8"   % "test"

--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingDrivers.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingDrivers.scala
@@ -1,10 +1,10 @@
 package com.github.takezoe.slick.blocking
 
-import slick.jdbc._
+import slick.driver._
 
-object BlockingDerbyDriver extends DerbyProfile with BlockingJdbcProfile
-object BlockingH2Driver extends H2Profile with BlockingJdbcProfile
-object BlockingHsqldbDriver extends HsqldbProfile with BlockingJdbcProfile
-object BlockingMySQLDriver extends MySQLProfile with BlockingJdbcProfile
-object BlockingPostgresDriver extends PostgresProfile with BlockingJdbcProfile
-object BlockingSQLiteDriver extends SQLiteProfile with BlockingJdbcProfile
+object BlockingDerbyDriver extends JdbcDriver with DerbyDriver with BlockingJdbcDriver
+object BlockingH2Driver extends JdbcDriver with H2Driver with BlockingJdbcDriver
+object BlockingHsqldbDriver extends JdbcDriver with HsqldbDriver with BlockingJdbcDriver
+object BlockingMySQLDriver extends JdbcDriver with MySQLDriver with BlockingJdbcDriver
+object BlockingPostgresDriver extends JdbcDriver with PostgresDriver with BlockingJdbcDriver
+object BlockingSQLiteDriver extends JdbcDriver with SQLiteDriver with BlockingJdbcDriver

--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
@@ -2,7 +2,7 @@ package com.github.takezoe.slick.blocking
 
 import java.sql.Connection
 
-import slick.ast.{CompiledStatement, Node, ResultSetMapping}
+import slick.ast.{BaseTypedType, CompiledStatement, Node, ResultSetMapping}
 import slick.driver.JdbcDriver
 import slick.profile.{BasicAction, BasicStreamingAction, RelationalDriver}
 import slick.dbio.SynchronousDatabaseAction
@@ -57,7 +57,7 @@ trait BlockingJdbcDriver extends BlockingRelationalDriver { profile: JdbcDriver 
       }
     }
   
-    implicit class RepQueryExecutor[E, U, R, T](rep: Rep[E])(implicit unpack: Shape[_ <: FlatShapeLevel, Rep[E], U, R]){
+    implicit class RepQueryExecutor[E: BaseTypedType](rep: Rep[E]){
       private val invoker = new QueryInvoker[E](queryCompiler.run(Query(rep).toNode).tree)
   
       def run(implicit s: JdbcBackend#Session): E = invoker.first

--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingProfile.scala
@@ -3,9 +3,10 @@ package com.github.takezoe.slick.blocking
 import java.sql.Connection
 
 import slick.ast.{CompiledStatement, Node, ResultSetMapping}
-import slick.basic.{BasicAction, BasicStreamingAction}
+import slick.driver.JdbcDriver
+import slick.profile.{BasicAction, BasicStreamingAction, RelationalDriver}
 import slick.dbio.SynchronousDatabaseAction
-import slick.jdbc.{ActionBasedSQLInterpolation, JdbcBackend, JdbcProfile, JdbcResultConverterDomain}
+import slick.jdbc.{ActionBasedSQLInterpolation, JdbcBackend, JdbcResultConverterDomain}
 import slick.relational._
 import slick.util.SQLBuilder
 
@@ -13,11 +14,11 @@ import scala.language.existentials
 import scala.language.higherKinds
 import scala.language.implicitConversions
 
-trait BlockingRelationalProfile extends RelationalProfile {
+trait BlockingRelationalDriver extends RelationalDriver {
   trait BlockingAPI extends API {}
 }
 
-trait BlockingJdbcProfile extends BlockingRelationalProfile { profile: JdbcProfile =>
+trait BlockingJdbcDriver extends BlockingRelationalDriver { profile: JdbcDriver =>
   val blockingApi = new BlockingAPI {}
 
   trait BlockingAPI extends super.BlockingAPI with ImplicitColumnTypes with slick.JdbcProfileBlockingSession {

--- a/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
+++ b/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
@@ -207,11 +207,12 @@ class SlickBlockingAPISpec extends FunSuite {
     }
   }
 
-  test("Transaction support with Query SELECT FOR UPDATE"){
-    testTransactionWithSelectForUpdate { implicit session =>
-      Users.map(_.id).forUpdate.list
-    }
-  }
+//  slick 3.1 doesn't support forUpdate
+//  test("Transaction support with Query SELECT FOR UPDATE"){
+//    testTransactionWithSelectForUpdate { implicit session =>
+//      Users.map(_.id).forUpdate.list
+//    }
+//  }
 
   test("Transaction support with Action SELECT FOR UPDATE"){
     testTransactionWithSelectForUpdate { implicit session =>


### PR DESCRIPTION
this is a version compatible with slick 3.1. we just need to figure out how to support several slick version. I see 2 options
* different artifact name (blocking-slick31, blocking-slick32)
* align versions with slick versioning (blocking-slick % 3.1, blocking-slick % 3.2)

I prefer the 1st one

PS: depends on #15 