### PR TITLE
configure sbt-release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ name := "blocking-slick-32"
 
 organization := "com.github.takezoe"
 
-version := "0.0.4"
-
 scalaVersion := "2.12.1"
 
 crossScalaVersions := List("2.11.8", "2.12.1")
@@ -50,3 +48,12 @@ pomExtra := (
       </developer>
     </developers>
 )
+
+releaseCrossBuild := true
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
+releaseTagName <<= (name, version) map { case (n, v) =>
+  //tagName will be like "SLICK-32-0.0.X"
+  s"${n.stripPrefix("blocking-").toUpperCase}-$v"
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.0.5-SNAPSHOT"


### PR DESCRIPTION
to publish a release 
> sbt release

I configured the sbt-release plugin to do cross publishing, to use the `publishSigned` task, and the tag name to include the slick version we are using from the artifact name so that when you publish the slick31 version the tag is not overridden.
