### PR TITLE
insertOrUpdate support fixes #22 for branch slick-31

### DIFF
--- a/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
+++ b/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
@@ -139,6 +139,17 @@ class SlickBlockingAPISpec extends FunSuite {
     
   }
 
+  test("insert insertOrUpdate"){
+    db.withSession { implicit session =>
+      Tables.schema.create
+
+      Users.insertOrUpdate(UsersRow(1, "takezoe", None))
+      assert(Users.length.run == 1)
+      Users.insertOrUpdate(UsersRow(1, "joao", None))
+      assert(Users.length.run == 1)
+    }
+  }
+
   test("withTransaction Query"){
     withTransaction(
        u => s => Users.insert(u)(s),


### PR DESCRIPTION
refactor BlockingQueryInvoker to use Action.run instead of copying code
from slick