### PR TITLE
Returning and into support for batch insert

### DIFF
--- a/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
+++ b/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
@@ -146,6 +146,19 @@ class SlickBlockingAPISpec extends FunSuite {
     
   }
 
+  test("insert multiple returning"){
+    db.withSession { implicit session =>
+      Tables.schema.create
+
+      val id = Users.returning(Users.map(_.id)) insertAll (UsersRow(1, "takezoe", None), UsersRow(2, "mrfyda", None))
+      assert(id == List(1, 2))
+      assert(Users.length.run == 2)
+      val u = (Users.returning(Users.map(_.id)).into((u, id) => u.copy(id = id))) insertAll (UsersRow(3, "takezoe", None), UsersRow(4, "mrfyda", None))
+      assert(u.map(_.id) == List(3, 4))
+      assert(Users.length.run == 4)
+    }
+  }
+
   test("insert insertOrUpdate"){
     db.withSession { implicit session =>
       Tables.schema.create


### PR DESCRIPTION
Adds support for combining `returning` and `into` when using batch insert methods `++=` and `insertAll`.