### PR TITLE
Add a synchronous method for executing plain sql queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ db.withSession { implicit session =>
 }
 ```
 
+Plain sql can be executed synchronously as well, even when composed together
+
+```
+db.withSession { implicit session =>
+  val id1 = 1
+  val id2 = 2
+  val name1 = "takezoe"
+  val name2 = "chibochibo"
+  val insert1 = sqlu"INSERT INTO USERS (ID, NAME) VALUES (${id1}, ${name1})" andThen sqlu"INSERT INTO USERS (ID, NAME) VALUES (${id2}, ${name2})"
+  insert1.run
+
+  val query = for {
+    count <- sql"SELECT COUNT(*) FROM USERS".as[Int].head
+    max <- sql"SELECT MAX(ID) FROM USERS".as[Int].head
+  } yield (count, max)
+  val (count1, max1) = query.run
+  assert(count1 == 2)
+  assert(max1 == 2)
+}
+```
+
+Note that using `flatMap` and `andThen` requires an `ExecutionContext`, but if you run that code synchronously that value will be ignored
+
 Transaction is available by using `withTransaction` instead of `withSession`:
 
 ```scala


### PR DESCRIPTION
I haven't exhuastively filled out the subclasses of `DBIOAction`, but this seems to work for my use cases. With this implicit you can now do
```
db.withSession { implicit session =>
  sql"SELECT * FROM foo".head.run
}
```
I'd like to add some test coverage, but first I figured I'd get some feedback