### PR TITLE
Changed: Don't try to rollback if the commit fails.

### DIFF
--- a/src/main/scala/slick/TransactionalJdbcBackend.scala
+++ b/src/main/scala/slick/TransactionalJdbcBackend.scala
@@ -21,13 +21,17 @@ trait JdbcProfileBlockingSession {
       val s = session.asInstanceOf[JdbcBackend#BaseSession]
       if(s.isInTransaction) f else {
         s.startInTransaction
-        var done = false
+        var functionExecuted = false
         try {
           val res = f
+          functionExecuted = true
           s.endInTransaction(s.conn.commit())
-          done = true
           res
-        } finally if(!done) s.endInTransaction(s.conn.rollback())
+        } finally {
+          if(!functionExecuted) {
+            s.endInTransaction(s.conn.rollback())
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
First of all, thank you for building blocking-slick. It is a life-saver for us.

In our code it is possible that transactions fail in the commit due to conflicting changes. In that case, the call to commit fails. This is handled with a retry in our code. After switching to blocking-slick we see exceptions as follows:

`
org.postgresql.util.PSQLException: Cannot rollback when autoCommit is enabled.
	at org.postgresql.jdbc.PgConnection.rollback(PgConnection.java:813) ~[postgresql-9.4.1212.jar:9.4.1212]
	at com.mchange.v2.c3p0.impl.NewProxyConnection.rollback(NewProxyConnection.java:1033) ~[c3p0-0.9.5.1.jar:0.9.5.1]
	at slick.JdbcProfileBlockingSession$BlockingSession.$anonfun$withTransaction$2(TransactionalJdbcBackend.scala:30) ~[blocking-slick-32_2.12-0.0.8.jar:na]
	at slick.JdbcProfileBlockingSession$BlockingSession$$Lambda$1287/212517363.apply$mcV$sp(Unknown Source) ~[na:na]
	at slick.jdbc.JdbcBackend$BaseSession.endInTransaction(JdbcBackend.scala:462) ~[slick_2.12-3.2.0.jar:na]
	at slick.JdbcProfileBlockingSession$BlockingSession.withTransaction(TransactionalJdbcBackend.scala:30) ~[blocking-slick-32_2.12-0.0.8.jar:na]
`
This happens because blocking slick tries to rollback even though the commit failed and the call to endInTransaction already reset the connection to autocommit=true.

In my opinion, the fix is to only try to rollback when we did not previously try to commit.

Let me know what you think.