### PR TITLE
fix long literal warnings

### DIFF
--- a/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
+++ b/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
@@ -274,13 +274,13 @@ class SlickBlockingAPISpec extends FunSuite {
       val f1 = Future{db.withTransaction { implicit session =>
         val l = selectForUpdate(session).length
         //default h2 lock timeout is 1000ms
-        Thread.sleep(3000l)
+        Thread.sleep(3000L)
         l
       }}
       
       //and try to update a row
       val f2 = Future{db.withTransaction { implicit session =>
-        Thread.sleep(500l)
+        Thread.sleep(500L)
         Users.filter(_.id === 1L).map(_.name).update("João")
       }}
       


### PR DESCRIPTION
https://github.com/scala/scala/commit/cef5a73d3c5945b3f2583962ef7004bf52b8ff20

```
Welcome to Scala 2.13.0-RC2 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_201).
Type in expressions for evaluation. Or try :help.

scala> 3l
        ^
       warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
res0: Long = 3

scala> 3L
res1: Long = 3
```